### PR TITLE
Fix offline handling for mock data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # crytrack
+
+CryptoDash is a simple demonstration dashboard for cryptocurrency prices.
+The app uses live data from the CoinGecko API when available and
+automatically falls back to built‑in mock data when the network request
+fails or the browser is offline.

--- a/app.js
+++ b/app.js
@@ -252,8 +252,12 @@ class CryptoDash {
         // Set a short timeout for API calls
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 5000);
-        
+
         try {
+            if (!navigator.onLine) {
+                throw new Error('offline');
+            }
+
             const response = await fetch(priceUrl, {
                 signal: controller.signal,
                 headers: {


### PR DESCRIPTION
## Summary
- gracefully handle offline mode by checking `navigator.onLine`
- document how the app uses mock data when network requests fail

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68464609cf60832d9fd5f74558386f7e